### PR TITLE
Enable using sudo without a password

### DIFF
--- a/default.py
+++ b/default.py
@@ -131,7 +131,7 @@ def connect_openvpn(config, restart=False, sudopassword=None):
         sudopassword = utils.keyboard(
             heading=_settings.get_string(3012), hidden=True)
     openvpn = vpn.OpenVPN(_openvpn, _settings.get_datapath(
-        config), ip=_ip, port=_port, args=_args, sudopwd=sudopassword, debug=(_settings['debug'] == 'true'))
+        config), ip=_ip, port=_port, args=_args, sudo=_sudo, sudopwd=sudopassword, debug=(_settings['debug'] == 'true'))
     try:
         if restart:
             openvpn.disconnect()

--- a/resources/lib/openvpn.py
+++ b/resources/lib/openvpn.py
@@ -110,13 +110,14 @@ class OpenVPNError(Exception):
 
 class OpenVPN:
 
-    def __init__(self, openvpn, ovpnconfig, ip='127.0.0.1', port=1337, sudopwd=None, args=None, timeout=1, debug=False):
+    def __init__(self, openvpn, ovpnconfig, ip='127.0.0.1', port=1337, sudo=False, sudopwd=None, args=None, timeout=1, debug=False):
         self.openvpn = openvpn
         self.ovpnconfig = ovpnconfig
         self.ip = ip
         self.port = int(port)
         self.args = args
         self.timeout = timeout
+        self.sudo = sudo
         self.sudopwd = sudopwd
         self.debug = debug
 
@@ -184,9 +185,12 @@ class OpenVPN:
 
         self._log_debug('Command line: [%s]' % cmdline)
 
-        if self.sudopwd:
+        if self.sudo:
             self._log_debug('Using sudo')
-            cmdline = 'echo \'%s\' | sudo -S %s' % (self.sudopwd, cmdline)
+            if self.sudopwd:
+                cmdline = 'echo \'%s\' | sudo -S %s' % (self.sudopwd, cmdline)
+            else:
+                cmdline = 'sudo %s' % (cmdline)
 
         self.process = subprocess.Popen(cmdline, cwd=self.workdir, shell=True,
                                         stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
It's possible to set up the sudoers file to allow certain sudo commands without using a password, while less secure this is more convenient.

I've modified the code to allow the use of sudo in this scenario without specifying a password
