### PR TITLE
1 new feature, 1 tweak

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.openvpn" name="OpenVPN" version="3.0.0" provider-name="brianhornsby">
+<addon id="script.openvpn" name="OpenVPN" version="3.1.0" provider-name="brianhornsby">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
 		<import addon="script.module.beautifulsoup" version="3.0.8"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 *** 3.1.0 ***
 Added ability to save your sudo pasword.
+If only single config exists, run it without prompting.
 
 *** 3.0.0 ***
 Updated plugin to use Kodi name. Updated copyright date. [1a88f6f]

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+*** 3.1.0 ***
+Added ability to save your sudo pasword.
+
 *** 3.0.0 ***
 Updated plugin to use Kodi name. Updated copyright date. [1a88f6f]
 

--- a/default.py
+++ b/default.py
@@ -69,8 +69,10 @@ _args = _settings['args']
 _sudo = (_settings['sudo'] == 'true')
 if _sudo:
     _sudopwdrequired = (_settings['sudopwdrequired'] == 'true')
+    _sudopwd = _settings['sudopwd']
 else:
     _sudopwdrequired = False
+    _sudopwd = ''
 
 log_debug('OpenVPN:    [%s]' % _openvpn)
 log_debug('Userdata:   [%s]' % _userdata)
@@ -133,8 +135,12 @@ def connect_openvpn(config, restart=False, sudopassword=None):
     global _state
 
     if _sudo and _sudopwdrequired and sudopassword is None:
-        sudopassword = utils.keyboard(
+        if not _sudopwd:
+            sudopassword = utils.keyboard(
             heading=_settings.get_string(3012), hidden=True)
+        else:
+            sudopassword = _sudopwd
+
     openvpn = vpn.OpenVPN(_openvpn, _settings.get_datapath(
         config), ip=_ip, port=_port, args=_args, sudo=_sudo, sudopwd=sudopassword, debug=(_settings['debug'] == 'true'))
     try:

--- a/default.py
+++ b/default.py
@@ -190,7 +190,12 @@ def select_ovpn():
             if response[1] is not None and response[2] is not None and config == os.path.splitext(os.path.basename(response[1]))[0]:
                 config = '%s - %s' % (config, response[2])
             configs.append(config)
-        idx = utils.select(_settings.get_string(3013), configs)
+
+        if len(configs) == 1:
+            idx = 0
+        else:
+            idx = utils.select(_settings.get_string(3013), configs)
+
         if idx >= 0:
             log_debug('Select: [%s]' % ovpnfiles[idx])
             return ovpnfiles[idx]

--- a/resources/language/english/strings.xml
+++ b/resources/language/english/strings.xml
@@ -15,6 +15,7 @@
 	<string id="2010">Script</string>
 	<string id="2011">Use sudo when running OpenVPN</string>
 	<string id="2012">Password is required</string>
+	<string id="2013">Sudo password</string>
 	<string id="2020">Advanced</string>
 	<string id="2021">Debug</string>
 	

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,6 +13,7 @@
 	<category label="2010">
 		<setting id="sudo" type="bool" label="2011" default="false"/>
 		<setting id="sudopwdrequired" type="bool" label="2012" default="true" enable="!eq(-1,false)"/>
+		<setting id="sudopwd" type="text" label="2013" option="hidden" default="" />
 	</category>
 	<category label="2020">
 		<setting id="debug" type="bool" label="2021" default="false"/>


### PR DESCRIPTION
Hi Brian,

My first ever pull request, please be gentle!

Thanks so much for this addon. Absolutely love it, but I made some tweaks to make it a bit quicker and easier for me and thought you might want to consider including them in the main release.

1. Enable saving of sudo password in settings (commit b180ed6). Gives users the option to save their sudo password so if it's required, it will automatically use it instead of prompting. If not saved, prompt as normal.

2. If only one .ovpn config exists, then load it without prompting(commit 9529cb0). Of course, if more than one exists, show the the normal prompt.

Feedback very much welcome.

Cheers dude.

G.