### PR TITLE
Ensure we get the full openvpn command line arguments

### DIFF
--- a/resources/lib/openvpn.py
+++ b/resources/lib/openvpn.py
@@ -73,7 +73,7 @@ def is_running(ip, port):
             data = interface.receive()
             if data.startswith('SUCCESS: pid='):
                 pid = int(data.split('=')[1])
-                cmdline = 'ps -fp %d' % pid
+                cmdline = 'ps -fwwp %d' % pid
                 ps = subprocess.Popen(cmdline, shell=True, stdout=subprocess.PIPE)
                 cmdline = ps.stdout.read()
                 ps.stdout.close()


### PR DESCRIPTION
When checking for openvpn aruguments, adding `ww` in the ps command ensures that we get the full command line.

This eventually ensures that we get `MyConfig - CONNECTED` instead of just `MyConfig` displayed in the OpenVPN menu.

See also [ps: full command is too long][1] on Unix & Linux forum.

[1]: https://unix.stackexchange.com/questions/91561/ps-full-command-is-too-long/91562#91562